### PR TITLE
Fix snapped highlights

### DIFF
--- a/rmrl/document.py
+++ b/rmrl/document.py
@@ -38,7 +38,9 @@ class DocumentPage:
         # On disk, these files are named by a UUID
         self.rmpath = f'{{ID}}/{pid}.rm'
         if not source.exists(self.rmpath):
-            # From the API, these files are just numbered
+            # From the API, these files are just numbered, however the
+            # json file for the highlights still uses the UUID-style pid.
+            pidhighlights = pid
             pid = str(pagenum)
             self.rmpath = f'{{ID}}/{pid}.rm'
 
@@ -51,7 +53,7 @@ class DocumentPage:
 
         # Try to load smart highlights
         self.highlightdict = None
-        highlightfilepath = f'{{ID}}.highlights/{pid}.json'
+        highlightfilepath = f'{{ID}}.highlights/{pidhighlights}.json'
         if source.exists(highlightfilepath):
             with source.open(highlightfilepath, 'r') as f:
                 self.highlightdict = json.load(f)

--- a/rmrl/lines.py
+++ b/rmrl/lines.py
@@ -108,12 +108,14 @@ def readHighlights(json):
             rects = []
             for h in range(n_highlights):
                 rects += json["highlights"][l][h]["rects"]
-                try:
-                    colors.append(json["highlights"][l][h]["color"])
-                except KeyError:
-                    # In case there is no "color" property, set color to yellow (3)
-                    colors.append(3)
-            
+                # For each of the rects, add an entry in the colors list
+                n_rects = len(json["highlights"][l][h]["rects"])
+                for r in range(n_rects):
+                    try:
+                        colors.append(json["highlights"][l][h]["color"])
+                    except KeyError:
+                        # In case there is no "color" property, set color to yellow (3)
+                        colors.append(3)
             #n_strokes = len(rects)
             strokes = []
             for r, c in zip(rects, colors):


### PR DESCRIPTION
For me (I use [`rmfuse`](https://github.com/rschroll/rmfuse)), only freehand highlights were shown in the PDF, the snapped highlights didn't show up at all. This PR fixes that.

Note, I haven't tried the fix when accessing the files directly, only via `rmfuse`, so maybe this PR breaks something there.

The fix consists of two parts:
- in document.py there seems to be a difference in page id (pid) for documents on disk (uses a UUID) vs. those retrieved via the   API (a  simple page number). The json file with highlight rectangles uses the UUID page id, also when using the API, which is once of the reasons why I didn't see them in the PDFs.
- The second reason why they didn't show up was the fact that a single snapped highlight in the highlights json file contains multiple rectangles. However, only one color entry was added for any given highlight. As a result the zip() function that was later used to add  each rectangle only iterated over the first `n_colors` rectangles  instead of them all.